### PR TITLE
Use CONDA_PREFIX env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ python -m pytest tests
 
 ## Known issues
 
-### Could not load native RDKit library
-Some Knime versions (like: 4.3.0) can't load RDKit library.
-You need to append to the `$CONDA_PREFIX/lib` path to the `LD_LIBRARY_PATH` variable where the `libfreetype` library is available:
+1. Could not load native RDKit library, libfreetype.so.6: cannot open shared object file
+Some Knime versions (like: 4.3.0) or environments can't load RDKit library.
+You need to append the `$CONDA_PREFIX/lib` path to the `LD_LIBRARY_PATH` variable where the `libfreetype` library is available:
 ```sh
 conda activate <env_name>
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CONDA_PREFIX/lib"

--- a/retropath2_wrapper/RetroPath2.py
+++ b/retropath2_wrapper/RetroPath2.py
@@ -664,7 +664,24 @@ def call_knime(
 
     try:
         printout = open(devnull, 'wb') if logger.level > 10 else None
+        # Hack to link libGraphMolWrap.so (RDKit) against libfreetype.so.6 (from conda)
+        is_ld_path_modified = False
+        if "CONDA_PREFIX" in os_environ.keys():
+            os_environ['LD_LIBRARY_PATH'] = os_environ.get(
+                'LD_LIBRARY_PATH',
+                ''
+            ) + ':' + os_path.join(
+                os_environ['CONDA_PREFIX'],
+                "lib"
+            )
+            is_ld_path_modified = True
+
         returncode = subprocess_call(cmd=" ".join(args), logger=logger)
+        if is_ld_path_modified:
+            os_environ['LD_LIBRARY_PATH'] = ':'.join(
+                os_environ['LD_LIBRARY_PATH'].split(':')[:-1]
+            )
+
         StreamHandler.terminator = "\n"
         logger.info(' {bold}OK{reset}'.format(bold=attr('bold'), reset=attr('reset')))
         return returncode


### PR DESCRIPTION
Safe way to use CONDA_PREFIX env variable needed for conda-forge to link `libGraphMolWrap.so` and `libfreetype.so.6`