### PR TITLE
feat(retropath2_wrapper): remove `--kpkg-install`, `--kzenodo` arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Implementation of the KNIME retropath2.0 workflow. Takes for input the minimal (
 ## Prerequisites
 
 * Python 3
-* KNIME (code was tested on 4.5.0 version)
+* KNIME (code was tested on `4.6.4`, `4.7.0` versions)
 
 ## Install
 
@@ -21,7 +21,7 @@ The tool tries to install the KNIME Anlytical Platform as well as the RetroPath2
 
 Install in the `<my_env>` conda environment:
 ```shell
-conda install -c conda-forge -n <my_env> retropath2_wrapper 
+conda install -c conda-forge -n <my_env> retropath2_wrapper
 ```
 
 ## Run
@@ -64,8 +64,6 @@ r_code = retropath2(
     )
 ```
 
-For convenience, the retropath2_wrapper make an attempt to install the KNIME application, and the needed KNIME dependancies. KNIME installation can be skipped by setting  `kexec` to the KNIME executable path, and KNIME dependancies can be skipped using `kpkg_install=False`.
-
 Already installed KNIME app can hence be used that way, eg:
 ```python
 from retropath2_wrapper import retropath2
@@ -76,7 +74,6 @@ r_code = retropath2(
     rules_file='/path/to/rules/file',
     outdir='/path/to/outdir'
     kexec='/Applications/KNIME 4.3.0.app/Contents/MacOS/knime',
-    kpkg_install=False
     )
 ```
 
@@ -85,13 +82,12 @@ Executions can be timed out using the `timeout` arguments (in minutes).
 ### Return codes
 
 `retropath2()` function returns one of the following codes:
-* 0: `No error`
-* 1: `Source has been found in the sink`
-* 2: `Cannot find source-in-sink file`
-* 3: `Running the RetroPath2.0 Knime program produced an OSError`
-* 4: `RetroPath2.0 has found no solution`
-* 5: `Time limit reached`
-
+* 0: No error
+* 1: File is not found
+* 2: Running the RetroPath2.0 Knime program produced an OSError
+* 3: InChI is malformated
+* 10: Source has been found in the sink (warning)
+* 11: No solution is found (warning)
 
 ## Tests
 Test can be run with the following commands:
@@ -105,6 +101,10 @@ python -m pytest tests
 To run functional tests, the environment variable `RP2_FUNCTIONAL=TRUE` is required.
 
 ### Knime dependencies
+
+Two options are available:
+1. You provide a path of the Knime executable through the argument `--kexec`. You need to have the following libraries installed: `org.knime.features.chem.types.feature.group`, `org.knime.features.datageneration.feature.group`, `org.knime.features.python.feature.group`, `org.rdkit.knime.feature.feature.group`
+2. `retropath2_wrapper` will install Knime for you by downloading the softwares available on Zenodo. You can choose a version among `4.6.4` or `4.7.0`. Optionally, you can locate a path for the installation. If an executable is found in the path, Knime will not be reinstalled.
 
 Knime software and packages are available at:
 * [KNIME](https://www.knime.com/)

--- a/retropath2_wrapper/Args.py
+++ b/retropath2_wrapper/Args.py
@@ -13,7 +13,6 @@ DEFAULT_MSC_TIMEOUT = 10  # minutes
 DEFAULT_KNIME_VERSION = "4.6.4"
 DEFAULT_RP2_VERSION = 'r20220104'
 KNIME_ZENODO = {"4.6.4": "7515771", "4.7.0": "7564938"} # Map to Zenodo ID
-DEFAULT_ZENODO_VERSION = "NA"
 RETCODES = {
     'OK': 0,
     'NoError': 0,
@@ -59,26 +58,28 @@ def _add_arguments(parser):
 
 
     ## Optional arguments
-    #
-    # KNIME options
-    parser.add_argument(
+    parser_in = parser.add_argument_group("Input arguments")
+    parser_in.add_argument(
         '--source_file',
         type=str,
         help='Path of file containing the InChI (not compliant with --source_name nor --source_inchi)'
     )
-    parser.add_argument(
+    parser_in.add_argument(
         '--source_name',
         type=str,
         default=None,
         help='Name of compound to produce (needs --inchi, not compliant with --source_file).'
     )
-    parser.add_argument(
+    parser_in.add_argument(
         '--source_inchi',
         type=str,
         default=None,
         help='InChI of compound to produce (not compliant with --source_file).'
     )
-    parser.add_argument(
+
+    # Knime
+    parser_knime = parser.add_argument_group("Knime arguments")
+    parser_knime.add_argument(
         '--kexec',
         type=str,
         default=None,
@@ -86,7 +87,7 @@ def _add_arguments(parser):
               downloaded if not already installed or path is \
               wrong).'
     )
-    parser.add_argument(
+    parser_knime.add_argument(
         '--kinstall',
         type=str,
         default=DEFAULT_KNIME_FOLDER,
@@ -94,26 +95,17 @@ def _add_arguments(parser):
               downloaded if not already installed or path is \
               wrong).'
     )
-    parser.add_argument(
+    parser_knime.add_argument(
         '--kver',
         type=str,
         default=DEFAULT_KNIME_VERSION,
+        choices=list(KNIME_ZENODO.keys()),
         help='version of KNIME (mandatory if --kexec is passed).',
     )
-    parser.add_argument(
-        '--kpkg_install',
-        action='store_true',
-        default=False,
-        help='Install Knime packages (default: False).'
-    )
-    parser.add_argument(
-        '--kzenodo',
-        choices=[DEFAULT_ZENODO_VERSION] + list(KNIME_ZENODO.keys()),
-        default=DEFAULT_ZENODO_VERSION,
-        help='install Knime and its dependencies from Zenodo.'
-    )
 
-    parser.add_argument(
+    # RetroPath2.0 workflow options
+    parser_rp = parser.add_argument_group("Retropath2.0 workflow")
+    parser_rp.add_argument(
         '--rp2_version',
         type=str,
         default=DEFAULT_RP2_VERSION,
@@ -121,13 +113,12 @@ def _add_arguments(parser):
         help=f'version of RetroPath2.0 workflow (default: {DEFAULT_RP2_VERSION}).'
     )
 
-    # RetroPath2.0 workflow options
-    parser.add_argument('--max_steps'    , type=int, default=3)
-    parser.add_argument('--topx'         , type=int, default=100)
-    parser.add_argument('--dmin'         , type=int, default=0)
-    parser.add_argument('--dmax'         , type=int, default=1000)
-    parser.add_argument('--mwmax_source' , type=int, default=1000)
-    parser.add_argument(
+    parser_rp.add_argument('--max_steps'    , type=int, default=3)
+    parser_rp.add_argument('--topx'         , type=int, default=100)
+    parser_rp.add_argument('--dmin'         , type=int, default=0)
+    parser_rp.add_argument('--dmax'         , type=int, default=1000)
+    parser_rp.add_argument('--mwmax_source' , type=int, default=1000)
+    parser_rp.add_argument(
         '--msc_timeout',
         type=int,
         default=DEFAULT_MSC_TIMEOUT,
@@ -136,7 +127,8 @@ def _add_arguments(parser):
     # parser.add_argument('--forward'      , action='store_true')
 
     # Program options
-    parser.add_argument(
+    parser_sp = parser.add_argument_group("Logging")
+    parser_sp.add_argument(
         '--log',
         metavar='ARG',
         type=str,
@@ -147,12 +139,13 @@ def _add_arguments(parser):
         default='def_info',
         help='Adds a console logger for the specified level (default: error)'
     )
-    parser.add_argument(
+    parser_sp.add_argument(
         '--silent',
         action='store_true',
         default=False,
         help='run %(prog)s silently'
     )
+
     parser.add_argument(
         '--version',
         action='version',

--- a/retropath2_wrapper/Args.py
+++ b/retropath2_wrapper/Args.py
@@ -9,18 +9,9 @@ from argparse import ArgumentParser
 from retropath2_wrapper._version import __version__
 
 
-__PACKAGE_FOLDER = os_path.dirname(
-    os_path.realpath(__file__)
-)
-DEFAULTS = {
-    'MSC_TIMEOUT': 10,  # minutes
-    'KNIME_VERSION': '4.6.4',
-    'RP2_VERSION': 'r20220104',
-    'ZENODO_VERSION': "NA",
-    'KNIME_PYTHON_VERSION': '4.6.0.v202206100850',
-    'KNIME_RDKIT_VERSION': '4.6.1.v202212212136',
-    'KNIME_FOLDER': __PACKAGE_FOLDER
-}
+DEFAULT_MSC_TIMEOUT = 10  # minutes
+DEFAULT_KNIME_VERSION = "4.6.4"
+DEFAULT_RP2_VERSION = 'r20220104'
 KNIME_ZENODO = {"4.6.4": "7515771", "4.7.0": "7564938"} # Map to Zenodo ID
 RETCODES = {
     'OK': 0,
@@ -33,6 +24,10 @@ RETCODES = {
     'OSError': 2,
     'InChI': 3
 }
+__PACKAGE_FOLDER = os_path.dirname(
+    os_path.realpath(__file__)
+)
+DEFAULT_KNIME_FOLDER = __PACKAGE_FOLDER
 
 
 def build_args_parser():
@@ -95,7 +90,7 @@ def _add_arguments(parser):
     parser_knime.add_argument(
         '--kinstall',
         type=str,
-        default=DEFAULTS['KNIME_FOLDER'],
+        default=DEFAULT_KNIME_FOLDER,
         help='path to KNIME executable file (KNIME will be \
               downloaded if not already installed or path is \
               wrong).'
@@ -113,23 +108,9 @@ def _add_arguments(parser):
     parser_rp.add_argument(
         '--rp2_version',
         type=str,
-        default=DEFAULTS['RP2_VERSION'],
+        default=DEFAULT_RP2_VERSION,
         choices=['v9', 'r20210127', 'r20220104', "r20220224"],
-        help=f'Version of RetroPath2.0 workflow (default: {DEFAULTS["RP2_VERSION"]}).'
-    )
-
-    parser.add_argument(
-        '--kpython_version',
-        type=str,
-        default=DEFAULTS['KNIME_PYTHON_VERSION'],
-        help=f'Version of KNIME\'s PYTHON (default: {DEFAULTS["KNIME_PYTHON_VERSION"]}).'
-    )
-
-    parser.add_argument(
-        '--krdkit_version',
-        type=str,
-        default=DEFAULTS['KNIME_RDKIT_VERSION'],
-        help=f'Version of RDKit KNIME\'s plugin (default: {DEFAULTS["KNIME_RDKIT_VERSION"]}).'
+        help=f'version of RetroPath2.0 workflow (default: {DEFAULT_RP2_VERSION}).'
     )
 
     parser_rp.add_argument('--max_steps'    , type=int, default=3)
@@ -140,8 +121,8 @@ def _add_arguments(parser):
     parser_rp.add_argument(
         '--msc_timeout',
         type=int,
-        default=DEFAULTS['MSC_TIMEOUT'],
-        help=f'Defines the time after which the RDKit MCS Aggregation method will stop searching for best match (default: {DEFAULTS["MSC_TIMEOUT"]}).'
+        default=DEFAULT_MSC_TIMEOUT,
+        help=f'Defines the time after which the RDKit MCS Aggregation method will stop searching for best match (default: {DEFAULT_MSC_TIMEOUT}).'
     )
     # parser.add_argument('--forward'      , action='store_true')
 

--- a/retropath2_wrapper/RetroPath2.py
+++ b/retropath2_wrapper/RetroPath2.py
@@ -46,12 +46,12 @@ def retropath2(
     kinstall: str = DEFAULT_KNIME_FOLDER,
     kexec: str = None, kver: str = DEFAULT_KNIME_VERSION,
     knime: Knime = None,
-    rp2_version: str = DEFAULTS['RP2_VERSION'],
+    rp2_version: str = DEFAULT_RP2_VERSION,
     max_steps: int = 3,
     topx: int = 100,
     dmin: int = 0, dmax: int = 1000,
     mwmax_source: int = 1000,
-    msc_timeout: int = DEFAULTS['MSC_TIMEOUT'],
+    msc_timeout: int = DEFAULT_MSC_TIMEOUT,
     logger: Logger = getLogger(__name__)
 ) -> Tuple[str, Dict]:
 

--- a/retropath2_wrapper/RetroPath2.py
+++ b/retropath2_wrapper/RetroPath2.py
@@ -31,7 +31,6 @@ from .Args import (
     DEFAULT_MSC_TIMEOUT,
     DEFAULT_KNIME_VERSION,
     DEFAULT_RP2_VERSION,
-    DEFAULT_ZENODO_VERSION,
     RETCODES,
 )
 from retropath2_wrapper.knime import Knime
@@ -45,8 +44,7 @@ def retropath2(
     sink_file: str, source_file: str, rules_file: str,
     outdir: str,
     kinstall: str = DEFAULT_KNIME_FOLDER,
-    kexec: str = None, kpkg_install: bool = True, kver: str = DEFAULT_KNIME_VERSION,
-    kzenodo_ver: str = DEFAULT_ZENODO_VERSION,
+    kexec: str = None, kver: str = DEFAULT_KNIME_VERSION,
     knime: Knime = None,
     rp2_version: str = DEFAULT_RP2_VERSION,
     max_steps: int = 3,
@@ -62,7 +60,6 @@ def retropath2(
     logger.debug(f'rules_file: {rules_file}')
     logger.debug(f'outdir: {outdir}')
     logger.debug(f'kexec: {kexec}')
-    logger.debug(f'kpkg_install: {kpkg_install}')
     logger.debug(f'kinstall: {kinstall}')
     logger.debug(f'kver: {kver}')
     logger.debug(f'rp2_version: {rp2_version}')
@@ -75,7 +72,7 @@ def retropath2(
 
     # Create Knime object
     if knime is None:
-        knime = Knime(kexec=kexec, kinstall=kinstall, is_kpkg_install=kpkg_install, kver=kver, kzenodo_ver=kzenodo_ver)
+        knime = Knime(kexec=kexec, kinstall=kinstall, kver=kver)
     if rp2_version is not None:
         knime.workflow = os_path.join(
             here, 'workflows', f'RetroPath2.0_{rp2_version}.knwf'
@@ -98,14 +95,9 @@ def retropath2(
         return r_code, None
 
     # Install KNIME
-    #      if kexec is not specified
-    #  and executable not detected in default path
-    knime.install_exec(logger=logger)
-    r_code = knime.install_pkgs(logger=logger)
+    r_code = knime.install(logger=logger)
     if r_code > 0:
         return r_code, None
-    elif r_code == RETCODES['OSError']:
-        return RETCODES['OSError'], None
 
     logger.info('{attr1}Initializing{attr2}'.format(attr1=attr('bold'), attr2=attr('reset')))
 

--- a/retropath2_wrapper/__main__.py
+++ b/retropath2_wrapper/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import sys
 from os import (
     path as os_path,
@@ -79,9 +80,7 @@ def _cli():
     knime = Knime(
         kexec=args.kexec,
         kinstall=args.kinstall,
-        is_kpkg_install=args.kpkg_install,
         kver=args.kver,
-        kzenodo_ver=args.kzenodo,
         workflow=os_path.join(here, 'workflows', 'RetroPath2.0_%s.knwf' % (args.rp2_version,)),
     )
     # Print out configuration
@@ -169,12 +168,15 @@ def check_scope(
 
 def parse_and_check_args(
     parser: ArgumentParser
-) -> None:
+):
 
     args = parser.parse_args()
 
-    if args.kver is None and args.kpkg_install and args.kexec is not None:
-        parser.error("--kexec requires --kver.")
+    if args.kexec is not None:
+        if not os.path.isfile(args.kexec):
+            parser.error("--kexec is not a file: %s" %(args.kexec,))
+        if not os.access(args.kexec, os.X_OK):
+            parser.error("--kexec is not executable: %s" %(args.kexec,))
 
     # Create outdir if does not exist
     if not os_path.exists(args.outdir):

--- a/retropath2_wrapper/knime.py
+++ b/retropath2_wrapper/knime.py
@@ -71,6 +71,7 @@ class Knime(object):
     KNIME_URL = "http://download.knime.org/analytics-platform/"
 
     def __init__(self, workflow: str="", kinstall: str=DEFAULT_KNIME_FOLDER, kver: str = DEFAULT_KNIME_VERSION, kexec: Optional[str]=None, *args, **kwargs) -> None:
+
         self.workflow = workflow
         self.kinstall = kinstall
         self.kver = kver
@@ -202,12 +203,7 @@ class Knime(object):
         logger.info('   |--url: ' + self.kurl)
         logger.info('   |--install_dir: ' + self.kinstall)
 
-    def install_pkgs(
-        self,
-        kpython_ver: str = None,
-        krdkit_ver: str = None,
-        logger: Logger = getLogger(__name__)
-    ) -> int:
+    def install_pkgs(self, logger: Logger = getLogger(__name__)) -> int:
         """Install KNIME packages needed to execute RetroPath2.0 workflow.
 
         Parameters
@@ -219,10 +215,6 @@ class Knime(object):
         ------
         int
         """
-        if kpython_ver is None:
-            kpython_ver = self.kpython_ver
-        if krdkit_ver is None:
-            krdkit_ver = self.krdkit_ver
         returncode = 0
         StreamHandler.terminator = ""
         logger.info( '   |- Checking KNIME packages...')

--- a/retropath2_wrapper/knime.py
+++ b/retropath2_wrapper/knime.py
@@ -23,7 +23,6 @@ from colored import attr
 from retropath2_wrapper.Args import (
     DEFAULT_KNIME_FOLDER,
     DEFAULT_KNIME_VERSION,
-    DEFAULT_ZENODO_VERSION,
     KNIME_ZENODO,
     RETCODES,
 )
@@ -45,16 +44,8 @@ class Knime(object):
         install or not Knime executable
     kinstall: str
         path install knime
-    kpkg_install: str
-        path to install knime packages
-    is_kpkg_install:
-        install or not Knime package
     kurl: str
         an url to download Knime (from Knime or Zenodo)
-    kzenodo_ver: str
-        the Knime version to download from Zenodo
-    is_zenodo: bool
-        use Zenodo to download executable and packages
     kzenodo_id: str
         Zenodo repository ID
 
@@ -79,33 +70,26 @@ class Knime(object):
     ZENODO_API = "https://zenodo.org/api/"
     KNIME_URL = "http://download.knime.org/analytics-platform/"
 
-    def __init__(self, workflow: str="", kinstall: str=DEFAULT_KNIME_FOLDER, kver: str = DEFAULT_KNIME_VERSION, is_kpkg_install: bool=False, kexec: Optional[str]=None, kzenodo_ver: str=DEFAULT_ZENODO_VERSION, *args, **kwargs) -> None:
+    def __init__(self, workflow: str="", kinstall: str=DEFAULT_KNIME_FOLDER, kver: str = DEFAULT_KNIME_VERSION, kexec: Optional[str]=None, *args, **kwargs) -> None:
 
         self.workflow = workflow
-        self.kver = kver
-        self.is_kpkg_install = is_kpkg_install
-        self.kexec = kexec
-        self.kzenodo_ver = kzenodo_ver
-        self.kexec_install = False
         self.kinstall = kinstall
+        self.kver = kver
+        self.kexec = kexec
+        self.kexec_install = False
         self.kpkg_install = ""
-        self.is_zenodo = False
+        self.kurl = ""
         self.kzenodo_id = ""
 
-        # Zenodo
-        self.is_zenodo = False
-        if self.kzenodo_ver != DEFAULT_ZENODO_VERSION:
-            self.kzenodo_id = KNIME_ZENODO[self.kzenodo_ver]
-            self.is_zenodo = True
-            self.kver = self.kzenodo_ver
+        # Setting kexec, kpath, kinstall, kver
+        if self.kexec is None:
+            self.kzenodo_id = KNIME_ZENODO[self.kver]
             zenodo_query = self.zenodo_show_repo()
             for zenodo_file in zenodo_query["files"]:
                 if sys.platform in zenodo_file["links"]["self"]:
                     self.kurl = zenodo_file["links"]["self"]
                     break
 
-        # Setting kexec, kpath, kinstall, kver
-        if self.kexec is None:
             self.kinstall = os.path.join(self.kinstall, '.knime', sys.platform)
             if sys.platform == 'darwin':
                 kpath = os.path.join(self.kinstall, f'KNIME_{self.kver}.app')
@@ -115,42 +99,42 @@ class Knime(object):
                 self.kexec = os.path.join(kpath, 'knime')
                 if sys.platform == 'win32':
                     self.kexec += '.exe'
+
+            # Check if exec already exists
             if not os.path.exists(self.kexec):
                 self.kexec_install = True
+
+            # Create url
+            self.kurl = ""
+            if self.kver != "":
+                if sys.platform == "linux":
+                    self.kurl = urllib.parse.urljoin(self.KNIME_URL, "linux/knime_%s.linux.gtk.x86_64.tar.gz" % (self.kver,))
+                elif sys.platform == "darwin":
+                    self.kurl = urllib.parse.urljoin(self.KNIME_URL, "macosx/knime_%s.app.macosx.cocoa.x86_64.dmg" % (self.kver,))
+                else:
+                    self.kurl = urllib.parse.urljoin(self.KNIME_URL, "win/knime_%s.win32.win32.x86_64.zip" % (self.kver,))
+
+            # Pkg variable
+            self.kpkg_install = kpath
+            if sys.platform == 'darwin':
+                self.kpkg_install = os.path.join(self.kpkg_install, 'Contents', 'Eclipse')
+
         else:
             if sys.platform in ['linux', 'darwin']:
                 self.kinstall = os.path.dirname(os.path.dirname(self.kexec))
             self.kver = ""
 
-        # Create url
-        self.kurl = ""
-        if self.kver != "":
-            if sys.platform == "linux":
-                self.kurl = urllib.parse.urljoin(self.KNIME_URL, "linux/knime_%s.linux.gtk.x86_64.tar.gz" % (self.kver,))
-            elif sys.platform == "darwin":
-                self.kurl = urllib.parse.urljoin(self.KNIME_URL, "macosx/knime_%s.app.macosx.cocoa.x86_64.dmg" % (self.kver,))
-            else:
-                self.kurl = urllib.parse.urljoin(self.KNIME_URL, "win/knime_%s.win32.win32.x86_64.zip" % (self.kver,))
-
-        # Pkg variable
-        if self.kexec_install or self.is_kpkg_install:
-            self.kpkg_install = kpath
-            if sys.platform == 'darwin':
-                self.kpkg_install = os.path.join(self.kpkg_install, 'Contents', 'Eclipse')
-
     def __repr__(self):
         s = ["Knime vars:"]
         s.append("workflow: " + self.workflow)
         s.append("kver: " + self.kver)
-        s.append("is_kpkg_install: " + str(self.kpkg_install))
         s.append("kpkg_install: " + self.kpkg_install)
         s.append("kexec: " + self.kexec)
         s.append("kexec_install: " + str(self.kexec_install))
         s.append("kinstall: " + self.kinstall)
-        s.append("kurl: " + self.kurl)
-        s.append("is_zenodo: " + str(self.is_zenodo))
-        if self.is_zenodo:
-            s.append("kzenodo_ver: " + self.kzenodo_ver)
+        if self.kurl != "":
+            s.append("kurl: " + self.kurl)
+        if self.kzenodo_id != "":
             s.append("kzenodo_id: " + self.kzenodo_id)
         return "\n".join(s)
 
@@ -194,31 +178,30 @@ class Knime(object):
         ------
         None
         """
-        if self.kexec_install:
-            logger.info('{attr1}Downloading KNIME {kver}...{attr2}'.format(attr1=attr('bold'), kver=self.kver, attr2=attr('reset')))
-            if sys.platform == 'linux':
-                download_and_extract_tar_gz(self.kurl, self.kinstall)
-                chown_r(self.kinstall, getuser())
-                # chown_r(kinstall, geteuid(), getegid())
-            elif sys.platform == 'darwin':
-                with tempfile.NamedTemporaryFile() as tempf:
-                    download(self.kurl, tempf.name)
-                    app_path = f'{self.kinstall}/KNIME_{self.kver}.app'
-                    if os.path.exists(app_path):
-                        shutil.rmtree(app_path)
-                    with tempfile.TemporaryDirectory() as tempd:
-                        cmd = f'hdiutil mount -noverify {tempf.name} -mountpoint {tempd}/KNIME'
-                        subprocess_call(cmd, logger=logger)
-                        shutil.copytree(
-                            f'{tempd}/KNIME/KNIME {self.kver}.app',
-                            app_path
-                        )
-                        cmd = f'hdiutil unmount {tempd}/KNIME'
-                        subprocess_call(cmd, logger=logger)
-            else:  # Windows
-                download_and_unzip(self.kurl, self.kinstall)
-            logger.info('   |--url: ' + self.kurl)
-            logger.info('   |--install_dir: ' + self.kinstall)
+        logger.info('{attr1}Downloading KNIME {kver}...{attr2}'.format(attr1=attr('bold'), kver=self.kver, attr2=attr('reset')))
+        if sys.platform == 'linux':
+            download_and_extract_tar_gz(self.kurl, self.kinstall)
+            chown_r(self.kinstall, getuser())
+            # chown_r(kinstall, geteuid(), getegid())
+        elif sys.platform == 'darwin':
+            with tempfile.NamedTemporaryFile() as tempf:
+                download(self.kurl, tempf.name)
+                app_path = f'{self.kinstall}/KNIME_{self.kver}.app'
+                if os.path.exists(app_path):
+                    shutil.rmtree(app_path)
+                with tempfile.TemporaryDirectory() as tempd:
+                    cmd = f'hdiutil mount -noverify {tempf.name} -mountpoint {tempd}/KNIME'
+                    subprocess_call(cmd, logger=logger)
+                    shutil.copytree(
+                        f'{tempd}/KNIME/KNIME {self.kver}.app',
+                        app_path
+                    )
+                    cmd = f'hdiutil unmount {tempd}/KNIME'
+                    subprocess_call(cmd, logger=logger)
+        else:  # Windows
+            download_and_unzip(self.kurl, self.kinstall)
+        logger.info('   |--url: ' + self.kurl)
+        logger.info('   |--install_dir: ' + self.kinstall)
 
     def install_pkgs(self, logger: Logger = getLogger(__name__)) -> int:
         """Install KNIME packages needed to execute RetroPath2.0 workflow.
@@ -233,50 +216,50 @@ class Knime(object):
         int
         """
         returncode = 0
-        if self.kexec_install or self.is_kpkg_install:
-            StreamHandler.terminator = ""
-            logger.info( '   |- Checking KNIME packages...')
-            logger.debug(f'        + kpkg_install: {self.kpkg_install}')
-            logger.debug(f'        + kver: {self.kver}')
+        StreamHandler.terminator = ""
+        logger.info( '   |- Checking KNIME packages...')
+        logger.debug(f'        + kpkg_install: {self.kpkg_install}')
+        logger.debug(f'        + kver: {self.kver}')
 
-            tmpdir = tempfile.mkdtemp()
+        tmpdir = tempfile.mkdtemp()
 
-            args = [self.kexec]
-            args += ['-application', 'org.eclipse.equinox.p2.director']
-            args += ['-nosplash']
-            args += ['-consoleLog']
-            if self.is_zenodo:
-                zenodo_query = self.zenodo_show_repo()
-                repositories = []
-                for zenodo_file in zenodo_query["files"]:
-                    url = zenodo_file["links"]["self"]
-                    if "update.analytics-platform" in url or "TrustedCommunityContributions" in url:
-                        repo_path = os.path.join(tmpdir, os.path.basename(url))
-                        download(url, repo_path)
-                        repositories.append(repo_path)
+        args = [self.kexec]
+        args += ['-application', 'org.eclipse.equinox.p2.director']
+        args += ['-nosplash']
+        args += ['-consoleLog']
+        # Download from Zenodo
+        zenodo_query = self.zenodo_show_repo()
+        repositories = []
+        for zenodo_file in zenodo_query["files"]:
+            url = zenodo_file["links"]["self"]
+            if "update.analytics-platform" in url or "TrustedCommunityContributions" in url:
+                repo_path = os.path.join(tmpdir, os.path.basename(url))
+                download(url, repo_path)
+                repositories.append(repo_path)
 
-                args += ["-r"]
-                args.append(",".join(["jar:file:%s!/" % (x,) for x in repositories]))
+        args += ["-r"]
+        args.append(",".join(["jar:file:%s!/" % (x,) for x in repositories]))
 
-            else:
-                args += ['-r', 'http://update.knime.org/community-contributions/trunk,' \
-                    + 'http://update.knime.com/community-contributions/trusted/'+self.kver[:3]+',' \
-                    + 'http://update.knime.com/analytics-platform/'+self.kver[:3]]
-            args += ["-i", 'org.knime.features.chem.types.feature.group,' \
-                + 'org.knime.features.datageneration.feature.group,' \
-                + 'org.knime.features.python.feature.group,' \
-                + 'org.rdkit.knime.feature.feature.group']
-            args += ['-bundlepool', self.kpkg_install]
-            args += ['-d', self.kpkg_install]
+        args += ["-i", 'org.knime.features.chem.types.feature.group,' \
+            + 'org.knime.features.datageneration.feature.group,' \
+            + 'org.knime.features.python.feature.group,' \
+            + 'org.rdkit.knime.feature.feature.group']
+        args += ['-bundlepool', self.kpkg_install]
+        args += ['-d', self.kpkg_install]
 
-            returncode = subprocess_call(" ".join(args), logger=logger)
-            StreamHandler.terminator = "\n"
-            shutil.rmtree(tmpdir, ignore_errors=True)
+        returncode = subprocess_call(" ".join(args), logger=logger)
+        StreamHandler.terminator = "\n"
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
-            logger.info(' OK')
-        else:
-            logger.info("Install packages is not requested")
+        logger.info(' OK')
         return returncode
+
+    def install(self, logger: Logger = getLogger(__name__)) -> int:
+        if self.kexec_install:
+            self.install_exec(logger=logger)
+            r_code = self.install_pkgs(logger=logger)
+            return r_code
+        return 0
 
     def call(
         self,

--- a/tests/test_knime.py
+++ b/tests/test_knime.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 
 import pytest
-from retropath2_wrapper.Args import DEFAULT_KNIME_VERSION, DEFAULT_ZENODO_VERSION, KNIME_ZENODO, RETCODES
+from retropath2_wrapper.Args import DEFAULT_KNIME_VERSION, KNIME_ZENODO, RETCODES
 from retropath2_wrapper.knime import Knime
 
 
@@ -59,7 +59,7 @@ class TestKnime:
     def test_install_knime_from_zenodo(self):
         tempdir = tempfile.mkdtemp()
 
-        knime = Knime(workflow="", kinstall=tempdir, kzenodo_ver=list(KNIME_ZENODO.keys())[0])
+        knime = Knime(workflow="", kinstall=tempdir, kver=list(KNIME_ZENODO.keys())[0])
         knime.install_exec()
         kexec = TestKnime.filter_exec(path=tempdir)
         assert kexec is not None

--- a/tests/test_retropath2.py
+++ b/tests/test_retropath2.py
@@ -31,7 +31,6 @@ class TestRetropath2:
             source_file=source_mnxm790_csv,
             rules_file=rules_csv,
             outdir=tempdir,
-            kzenodo_ver=list(KNIME_ZENODO.keys())[0],
             logger=logger,
         )
         assert r_code == RETCODES['SrcInSink']
@@ -49,7 +48,6 @@ class TestRetropath2:
             kinstall=tempdir,
             outdir=tempdir,
             msc_timeout=10,
-            kzenodo_ver=list(KNIME_ZENODO.keys())[0],
             logger=logger,
         )
         # Specific test for windows due to Github Runner memory consumption.


### PR DESCRIPTION
BREAKING CHANGE: Remove arguments from command line Simply how Knime is handled:
* Knime executable is provided by the user
* It will be downloaded from Zenodo. Custom install directory and version are allowed.