### PR TITLE
Fix Knime Subprocess

### DIFF
--- a/retropath2_wrapper/knime.py
+++ b/retropath2_wrapper/knime.py
@@ -21,6 +21,7 @@ from brs_utils  import (
     download,
     download_and_unzip,
     chown_r,
+    subprocess_call,
 )
 from retropath2_wrapper.Args import (
     DEFAULTS,


### PR DESCRIPTION
Error encountered:
`Couldn't parse -workflow.variable argument: -workflow.variable=input.std_mode,"H: Invalid argument list`

By-pass `brs-utils.subprocess.call` by `subprocess.run` to use a List of arguments directly
