### PR TITLE
Install and use Knime smoothly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/retropath2_wrapper/badges/version.svg)](https://anaconda.org/conda-forge/retropath2_wrapper) [![Anaconda-Server Badge](https://anaconda.org/conda-forge/retropath2_wrapper/badges/latest_release_date.svg)](https://anaconda.org/conda-forge/retropath2_wrapper)
 
-Implementation of the KNIME retropath2.0 workflow. Takes for input the minimal (dmin) and maximal (dmax) diameter for the reaction rules and the maximal path length (maxSteps). The tool  expects the following files: `rules.csv`, `sink.csv` and `source.csv` and produces results in an output folder.
+Implementation of the KNIME retropath2.0 workflow. Takes for input the minimal (dmin) and maximal (dmax) diameter for the reaction rules and the maximal path length (maxSteps). The tool expects the following files: `rules.csv`, `sink.csv` and `source.csv` and produces results in an output folder.
 
 ## Prerequisites
 
-* Python 3
-* KNIME (code was tested on `4.6.4`, `4.7.0` versions)
+- Python 3
+- KNIME (code was tested on `4.6.4`, `4.7.0` versions)
 
 ## Install
 
@@ -20,6 +20,7 @@ The tool tries to install the KNIME Anlytical Platform as well as the RetroPath2
 ### conda package
 
 Install in the `<my_env>` conda environment:
+
 ```shell
 conda install -c conda-forge -n <my_env> retropath2_wrapper
 ```
@@ -29,6 +30,7 @@ conda install -c conda-forge -n <my_env> retropath2_wrapper
 **Disclaimer**: we recommand to provide absolute path to files, problems can arise with relative paths.
 
 ### From CLI (Linux, macOS)
+
 ```sh
 python -m retropath2_wrapper <sink-file> <rules-file> <out-dir> --source_file <source-file>
 ```
@@ -36,6 +38,7 @@ python -m retropath2_wrapper <sink-file> <rules-file> <out-dir> --source_file <s
 ### From Python code
 
 The minimal required arguments are `sink_file`, `source_file`, `rules_file` and `outdir`.
+
 ```python
 from retropath2_wrapper import retropath2
 
@@ -48,6 +51,7 @@ r_code = retropath2(
 ```
 
 Exploration settings have default values and can be tuned:
+
 ```python
 from retropath2_wrapper import retropath2
 
@@ -65,15 +69,21 @@ r_code = retropath2(
 ```
 
 Already installed KNIME app can hence be used that way, eg:
+
 ```python
 from retropath2_wrapper import retropath2
+from retropath2_wrapper.knime import Knime
 
+knime = Knime(
+    kinstall="/path/to/knime/directory",
+    workflow="/path/to/workflow",
+)
 r_code = retropath2(
     sink_file='/path/to/sink/file',
     source_file='/path/to/source/file',
     rules_file='/path/to/rules/file',
     outdir='/path/to/outdir'
-    kexec='/Applications/KNIME 4.3.0.app/Contents/MacOS/knime',
+    knime=knime,
     )
 ```
 
@@ -82,17 +92,22 @@ Executions can be timed out using the `timeout` arguments (in minutes).
 ### Return codes
 
 `retropath2()` function returns one of the following codes:
-* 0: No error
-* 1: File is not found
-* 2: Running the RetroPath2.0 Knime program produced an OSError
-* 3: InChI is malformated
-* 10: Source has been found in the sink (warning)
-* 11: No solution is found (warning)
+
+- 0: No error
+- 1: File is not found
+- 2: Running the RetroPath2.0 Knime program produced an OSError
+- 3: InChI is malformated
+- 4: Sink file is malformed
+- 5: Knime installation returns an error
+- 10: Source has been found in the sink (warning)
+- 11: No solution is found (warning)
 
 ## Tests
+
 Test can be run with the following commands:
 
 ### Natively
+
 ```sh
 conda install -c conda-forge pytest
 python -m pytest tests
@@ -102,30 +117,40 @@ To run functional tests, the environment variable `RP2_FUNCTIONAL=TRUE` is requi
 
 ### Knime dependencies
 
-Two options are available:
-1. You provide a path of the Knime executable through the argument `--kexec`. You need to have the following libraries installed: `org.knime.features.chem.types.feature.group`, `org.knime.features.datageneration.feature.group`, `org.knime.features.python.feature.group`, `org.rdkit.knime.feature.feature.group`
-2. `retropath2_wrapper` will install Knime for you by downloading the softwares available on Zenodo. You can choose a version among `4.6.4` or `4.7.0`. Optionally, you can locate a path for the installation. If an executable is found in the path, Knime will not be reinstalled.
+Availbale options:
+
+1. You provide a path of the Knime root directory through the argument `--kinstall`. You need to have the following libraries installed: `org.knime.features.chem.types.feature.group`, `org.knime.features.datageneration.feature.group`, `org.knime.features.python.feature.group`, `org.rdkit.knime.feature.feature.group`
+2. `retropath2_wrapper` will install Knime for you, at the root of the python package, by downloading the softwares available on Zenodo. You can choose a version among `4.6.4` or `4.7.0`. Optionally, you can locate a path for the installation. If an executable is found in the path, Knime will not be reinstalled.
+
+```bash
+python -m retropath2_wrapper.knime \
+    --kinstall "/path/to/knime/root/dir" \
+    --kver {4.6.4,4.7.0}
+```
 
 Knime software and packages are available at:
-* [KNIME](https://www.knime.com/)
-* [KNIME v4.6.4 - Zenodo](https://zenodo.org/record/7515771)
-* [KNIME v4.7.0 - Zenodo](https://zenodo.org/record/7564938)
+
+- [KNIME](https://www.knime.com/)
+- [KNIME v4.6.4 - Zenodo](https://zenodo.org/record/7515771)
+- [KNIME v4.7.0 - Zenodo](https://zenodo.org/record/7564938)
 
 ## Known issues
 
 1. Could not load native RDKit library, libfreetype.so.6: cannot open shared object file
-Some Knime versions (like: 4.3.0) or environments can't load RDKit library.
-You need to append the `$CONDA_PREFIX/lib` path to the `LD_LIBRARY_PATH` variable where the `libfreetype` library is available:
+   Some Knime versions (like: 4.3.0) or environments can't load RDKit library.
+   You need to append the `$CONDA_PREFIX/lib` path to the `LD_LIBRARY_PATH` variable where the `libfreetype` library is available:
+
 ```sh
 conda activate <env_name>
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CONDA_PREFIX/lib"
 ```
 
 ## CI/CD
+
 For further tests and development tools, a CI toolkit is provided in `cicd-toolkit` folder (see [cicd-toolkit/README.md](cicd-toolit/README.md)).
 
-
 ### How to cite RetroPath2.0?
+
 Please cite:
 
 Delépine B, Duigou T, Carbonell P, Faulon JL. RetroPath2.0: A retrosynthesis workflow for metabolic engineers. Metabolic Engineering, 45: 158-170, 2018. DOI: https://doi.org/10.1016/j.ymben.2017.12.002

--- a/retropath2_wrapper/Args.py
+++ b/retropath2_wrapper/Args.py
@@ -15,37 +15,10 @@ __PACKAGE_FOLDER = os_path.dirname(
 )
 DEFAULTS = {
     'MSC_TIMEOUT': 10,  # minutes
-    'KNIME_VERSION': "4.6.4",
     'RP2_VERSION': 'r20250728',
     'KNIME_FOLDER': __PACKAGE_FOLDER,
-    'KNIME_REPOS': [
-            # 'http://update.knime.com/partner/',
-            'http://update.knime.com/community-contributions/trunk/',
-            'http://update.knime.com/community-contributions/trusted/4.6',
-            'http://update.knime.com/analytics-platform/4.6'
-        ],
-    'KNIME_PLUGINS': ','.join(
-        [
-            'org.knime.base',
-            'org.knime.python.nodes',
-            'org.knime.datageneration',
-            'org.knime.chem.base',
-            'org.rdkit.knime.feature.feature.group/4.8.1.v202312052327',
-            'org.rdkit.knime.nodes/4.8.1.v202312052327',
-            # 'org.knime.python.nodes/4.6.0.v202203011403',
-            # 'org.knime.datageneration/4.6.0.v202202251621',
-            # 'org.knime.chem.base/4.6.0.v202202251610',
-            # 'org.rdkit.knime.feature.feature.group/4.8.1.v202312052327',
-            # 'org.rdkit.knime.nodes/4.8.1.v202312052327',
-        ]
-    ),
-    'NO_NETWORK': False,
     "STD_HYDROGEN": "auto",  # How hydrogens are represented in chemical rules
 }
-# DEFAULTS['KNIME_PLUGINS'] = ','.join(
-#     [pkg.split('/')[0] for pkg in DEFAULTS['KNIME_PLUGINS'].split(',')]
-# )
-KNIME_ZENODO = {"4.6.4": "7515771", "4.7.0": "7564938"} # Map to Zenodo ID
 RETCODES = {
     'OK': 0,
     'NoError': 0,
@@ -57,6 +30,7 @@ RETCODES = {
     'OSError': 2,
     'InChI': 3,
     'SinkFileMalformed': 4,
+    'KnimeInstallationError': 5,
 }
 
 
@@ -110,33 +84,10 @@ def _add_arguments(parser):
     # Knime
     parser_knime = parser.add_argument_group("Knime arguments")
     parser_knime.add_argument(
-        '--kexec',
-        type=str,
-        default=None,
-        help='path to KNIME executable file (KNIME will be \
-              downloaded if not already installed or path is \
-              wrong).'
-    )
-    parser_knime.add_argument(
         '--kinstall',
         type=str,
         default=DEFAULTS['KNIME_FOLDER'],
-        help='path to KNIME executable file (KNIME will be \
-              downloaded if not already installed or path is \
-              wrong).'
-    )
-    parser_knime.add_argument(
-        '--kver',
-        type=str,
-        default=DEFAULTS['KNIME_VERSION'],
-        choices=list(KNIME_ZENODO.keys()),
-        help='version of KNIME (mandatory if --kexec is passed).',
-    )
-    parser_knime.add_argument(
-        '--kplugins',
-        type=str,
-        default="",
-        help='KNIME plugins to use (separated by a comma).',
+        help='Directory where to find a KNIME executable file',
     )
 
     # RetroPath2.0 workflow options
@@ -147,14 +98,6 @@ def _add_arguments(parser):
         default=DEFAULTS['RP2_VERSION'],
         choices=['v9', 'r20210127', 'r20220104', "r20220224", "r20250728"],
         help=f'version of RetroPath2.0 workflow (default: {DEFAULTS["RP2_VERSION"]}).'
-    )
-
-    # No network option
-    parser_rp.add_argument(
-        '--no-network',
-        action='store_true',
-        default=DEFAULTS['NO_NETWORK'],
-        help='Do not use network.'
     )
 
     parser_rp.add_argument('--max_steps'    , type=int, default=3)

--- a/retropath2_wrapper/RetroPath2.py
+++ b/retropath2_wrapper/RetroPath2.py
@@ -45,11 +45,7 @@ def retropath2(
     rules_file: str,
     outdir: str,
     std_hydrogen: str,
-    kinstall: str = DEFAULTS['KNIME_FOLDER'],
-    kexec: str = None,
-    kver: str = DEFAULTS['KNIME_VERSION'],
-    knime: Knime = None,
-    kplugins: list = DEFAULTS['KNIME_PLUGINS'],
+    knime: Knime,
     rp2_version: str = DEFAULTS['RP2_VERSION'],
     max_steps: int = 3,
     topx: int = 100,
@@ -65,9 +61,6 @@ def retropath2(
     logger.debug(f'rules_file: {rules_file}')
     logger.debug(f'outdir: {outdir}')
     logger.debug(f'std_hydrogen: {std_hydrogen}')
-    logger.debug(f'kexec: {kexec}')
-    logger.debug(f'kinstall: {kinstall}')
-    logger.debug(f'kver: {kver}')
     logger.debug(f'rp2_version: {rp2_version}')
     logger.debug(f'max_steps: {max_steps}')
     logger.debug(f'topx: {topx}')
@@ -78,12 +71,15 @@ def retropath2(
 
     # Create Knime object
     if knime is None:
-        knime = Knime(kexec=kexec, kinstall=kinstall, kver=kver)
+        knime = Knime()
     if rp2_version is not None:
         knime.workflow = os_path.join(
             here, 'workflows', f'RetroPath2.0_{rp2_version}.knwf'
         )
-
+    if knime.kexec == "":
+        # Install KNIME
+        if not knime.install(kver=Knime.DEFAULT_VERSION, logger=logger):
+            return RETCODES["KnimeInstallationError"]
     logger.debug('knime: ' + str(knime))
 
     # Store RetroPath2 params into a dictionary
@@ -99,11 +95,6 @@ def retropath2(
 
     r_code, inchi = check_input(source_file, sink_file)
     if r_code != RETCODES['OK']:
-        return r_code, None
-
-    # Install KNIME
-    r_code = knime.install(logger=logger)
-    if r_code > 0:
         return r_code, None
 
     logger.info('{attr1}Initializing{attr2}'.format(attr1=attr('bold'), attr2=attr('reset')))

--- a/retropath2_wrapper/__main__.py
+++ b/retropath2_wrapper/__main__.py
@@ -79,18 +79,11 @@ def _cli():
 
     # Create Knime object
     here = os_path.dirname(os_path.realpath(__file__))
-    if args.kplugins == "":
-        kplugins = []
-    else:
-        kplugins = args.kplugins.split(',')
     knime = Knime(
-        kexec=args.kexec,
         kinstall=args.kinstall,
-        kver=args.kver,
-        kplugins=kplugins,
         workflow=os_path.join(here, 'workflows', 'RetroPath2.0_%s.knwf' % (args.rp2_version,)),
-        network=not args.no_network,
     )
+
     # Print out configuration
     if not args.silent and args.log.lower() not in ['critical', 'error']:
         print_conf(knime, prog = parser.prog)
@@ -193,12 +186,6 @@ def parse_and_check_args(
 ):
 
     args = parser.parse_args()
-
-    if args.kexec is not None:
-        if not os.path.isfile(args.kexec):
-            parser.error("--kexec is not a file: %s" %(args.kexec,))
-        if not os.access(args.kexec, os.X_OK):
-            parser.error("--kexec is not executable: %s" %(args.kexec,))
 
     # Create outdir if does not exist
     if not os_path.exists(args.outdir):

--- a/retropath2_wrapper/knime.py
+++ b/retropath2_wrapper/knime.py
@@ -1,3 +1,5 @@
+import argparse
+import glob
 import os
 import requests
 import shutil
@@ -25,36 +27,9 @@ from brs_utils  import (
 )
 from retropath2_wrapper.Args import (
     DEFAULTS,
-    KNIME_ZENODO,
     RETCODES,
 )
 from retropath2_wrapper.preference import Preference
-
-
-class KPlugin():
-    """ A Knime package/plugin class"""
-
-    def __init__(self, name: str):
-        name_version = name.split("/")
-        self.name = name_version[0]
-        self.version = name_version[1] if len(name_version) > 1 else ""
-
-    def __repr__(self):
-        if self.version != "":
-            return f"{self.name}/{self.version}"
-        return f"{self.name}"
-
-    def __eq__(self, other):
-        return self.name == other.name and self.version == other.version
-
-    def __lt__(self, other):
-        return self.version < other.version
-    
-    def __hash__(self):
-        return hash(self.name)
-    
-    def has_version(self):
-        return self.version != ""
 
 
 class Knime(object):
@@ -62,145 +37,47 @@ class Knime(object):
 
     Attributes
     ----------
+    kinstall: str
+        directory to found a "knime" executable
     workflow: str
         path of the Knime workflow
-    kver: str
-        knime version to download, install or use
-    kexec: str
-        path of Knime executable
-    kexec_install: bool
-        install or not Knime executable
-    kinstall: str
-        path install knime
-    kurl: str
-        an url to download Knime (from Knime or Zenodo)
-    kzenodo_id: str
-        Zenodo repository ID
-
-    Methods
-    -------
-    zenodo_show_repo(self) -> Dict[str, Any]
-        Show Zenodo repository informations.
-
-    @classmethod
-
-    def standardize_path(cls, path: str) -> str
-        Path are given with double backslashes on windows.
-
-    install_exec(self, logger: Logger = getLogger(__name__)) -> None
-        Install Knime executable
-
-    install_pkgs(self, logger: Logger = getLogger(__name__)) -> int
-        Install KNIME packages needed to execute RetroPath2.0 workflow.
-
-    call(self, files: Dict, params: Dict, preference: Preference, logger: Logger = getLogger(__name__)) -> int
-        Run Knime workflow.
     """
     ZENODO_API = "https://zenodo.org/api/"
     KNIME_URL = "http://download.knime.org/analytics-platform/"
-
+    ZENODO = {
+        "4.6.4": "7515771",
+        "4.7.0": "7564938",
+    }
+    DEFAULT_VERSION = "4.6.4"
 
     def __init__(
             self,
-            workflow: str = "",
             kinstall: str = DEFAULTS['KNIME_FOLDER'],
-            kver: str = DEFAULTS['KNIME_VERSION'],
-            kexec: Optional[str] = None,
-            kplugins: Optional[str] = DEFAULTS['KNIME_PLUGINS'],
-            network: bool = not DEFAULTS['NO_NETWORK'],
-            *args,
-            **kwargs
+            workflow: str = "",
         ) -> None:
-
-        self.workflow = workflow
         self.kinstall = kinstall
-        self.kver = kver
-        self.kexec = kexec
-        self.kexec_install = False
-        self.kpkg_install = ""
-        self.kurl = ""
-        self.kzenodo_id = ""
-        self.network = network
-
-        # Setting kexec, kpath, kinstall, kver
-        if self.kexec is None:
-
-            if not self.network:
-                raise ValueError('Network is disabled (--no-network) and no KNIME executable is provided (--kexec).')
-
-            self.kzenodo_id = KNIME_ZENODO[self.kver]
-            zenodo_query = self.__zenodo_show_repo()
-            for zenodo_file in zenodo_query["files"]:
-                if sys.platform in zenodo_file["links"]["self"]:
-                    self.kurl = zenodo_file["links"]["self"]
-                    break
-
-            self.kinstall = os.path.join(self.kinstall, '.knime', sys.platform)
-            if sys.platform == 'darwin':
-                kpath = os.path.join(self.kinstall, f'KNIME_{self.kver}.app')
-                self.kexec = os.path.join(kpath, 'Contents', 'MacOS', 'knime')
-            else:
-                kpath = os.path.join(self.kinstall, f'knime_{self.kver}')
-                self.kexec = os.path.join(kpath, 'knime')
-                if sys.platform == 'win32':
-                    self.kexec += '.exe'
-
-            # Check if exec already exists
-            if not os.path.exists(self.kexec):
-                self.kexec_install = True
-
-            # Create url
-            self.kurl = ""
-            if self.kver != "":
-                if sys.platform == "linux":
-                    self.kurl = urllib.parse.urljoin(self.KNIME_URL, "linux/knime_%s.linux.gtk.x86_64.tar.gz" % (self.kver,))
-                elif sys.platform == "darwin":
-                    self.kurl = urllib.parse.urljoin(self.KNIME_URL, "macosx/knime_%s.app.macosx.cocoa.x86_64.dmg" % (self.kver,))
-                else:
-                    self.kurl = urllib.parse.urljoin(self.KNIME_URL, "win/knime_%s.win32.win32.x86_64.zip" % (self.kver,))
-
-            # Pkg variable
-            self.kpkg_install = kpath
-            if sys.platform == 'darwin':
-                self.kpkg_install = os.path.join(self.kpkg_install, 'Contents', 'Eclipse')
-
-        else:
-            if sys.platform in ['linux', 'darwin']:
-                self.kinstall = os.path.dirname(os.path.dirname(self.kexec))
-            self.kver = ""
-
-        self.kplugins = kplugins
-        self.plugins_default = list(
-            map(KPlugin, DEFAULTS['KNIME_PLUGINS'].split(','))
-        )
-
+        self.workflow = workflow
+        self.kexec = Knime.find_executable(path=self.kinstall)
 
     def __repr__(self):
-        s = ["Knime vars:"]
-        s.append("workflow: " + self.workflow)
-        s.append("kver: " + self.kver)
-        s.append("kpkg_install: " + self.kpkg_install)
-        s.append("kexec: " + self.kexec)
-        s.append("kexec_install: " + str(self.kexec_install))
-        s.append("kinstall: " + self.kinstall)
-        if self.kurl != "":
-            s.append("kurl: " + self.kurl)
-        if self.kzenodo_id != "":
-            s.append("kzenodo_id: " + self.kzenodo_id)
+        s = []
+        s.append(f"workflow: {self.workflow}")
+        s.append(f"kinstall: {self.kinstall}")
+        s.append(f"kexec: {self.kexec}")
         return "\n".join(s)
 
-
-    def __zenodo_show_repo(self) -> Dict[str, Any]:
+    @classmethod
+    def zenodo_show_repo(cls, kver: str) -> Dict[str, Any]:
         """Show Zenodo repository informations.
 
         Return
         ------
         Dict[str, Any]
         """
-        if not self.network:
-            raise ValueError('Unable to show the zeonodo repo beacause network is disabled (--no-network).')
+        
+        kzenodo_id = Knime.ZENODO[kver]
         url = urllib.parse.urljoin(
-            self.ZENODO_API, "records/%s" % (self.kzenodo_id,)
+            Knime.ZENODO_API, f"records/{kzenodo_id}"
         )
         r = requests.get(url)
         if r.status_code > 202:
@@ -208,7 +85,6 @@ class Knime(object):
         return r.json()
 
     @classmethod
-
     def standardize_path(cls, path: str) -> str:
         """Path are given with double backslashes on windows.
         Knime needs a path with simple slash in commandline.
@@ -226,258 +102,88 @@ class Knime(object):
             path = "/".join(path.split(os.sep))
         return path
 
+    @classmethod
+    def find_executable(cls, path: str) -> str:
+        for root, _, files in os.walk(path):
+            for file in files:
+                path_file = os.path.join(root, file)
+                if os.access(path_file, os.X_OK) and os.path.isfile(path_file):
+                    if file.lower() == "knime":
+                        return os.path.abspath(path_file)
+        return ""
 
-    def __install_exec(self, logger: Logger = getLogger(__name__)) -> None:
-        """Install Knime executable
+    @classmethod
+    def find_p2_dir(cls, path: str) -> str:
+        for root, _, files in os.walk(path):
+            for file in files:
+                path_file = os.path.join(root, file)
+                if file == "p2" and os.path.isdir(path_file):
+                    return os.path.abspath(path_file)
+        return ""
 
-        Return
-        ------
-        None
-        """
-        logger.info('{attr1}Downloading KNIME {kver}...{attr2}'.format(attr1=attr('bold'), kver=self.kver, attr2=attr('reset')))
-        if sys.platform == 'linux':
-            download_and_extract_tar_gz(self.kurl, self.kinstall)
-            chown_r(self.kinstall, getuser())
-            # chown_r(kinstall, geteuid(), getegid())
-        elif sys.platform == 'darwin':
-            with tempfile.NamedTemporaryFile() as tempf:
-                download(self.kurl, tempf.name)
-                app_path = f'{self.kinstall}/KNIME_{self.kver}.app'
-                if os.path.exists(app_path):
-                    shutil.rmtree(app_path)
-                with tempfile.TemporaryDirectory() as tempd:
-                    cmd = f'hdiutil mount -noverify {tempf.name} -mountpoint {tempd}/KNIME'
-                    subprocess_call(cmd, logger=logger)
-                    shutil.copytree(
-                        f'{tempd}/KNIME/KNIME {self.kver}.app',
-                        app_path
-                    )
-                    cmd = f'hdiutil unmount {tempd}/KNIME'
-                    subprocess_call(cmd, logger=logger)
-        else:  # Windows
-            download_and_unzip(self.kurl, self.kinstall)
-        logger.info('   |--url: ' + self.kurl)
-        logger.info('   |--install_dir: ' + self.kinstall)
+    def install(self, kver: str, logger: Logger = getLogger(__name__)) -> bool:
+        data = Knime.zenodo_show_repo(kver=kver)
+        # Install Knime
+        for file in data["files"]:
+            basename = file["key"]
+            url = file["links"]["self"]
+            if "linux" in basename and sys.platform == "linux":
+                download_and_extract_tar_gz(url, self.kinstall)
+                chown_r(self.kinstall, getuser())
+                # chown_r(kinstall, geteuid(), getegid())
+                break
+            elif "macosx" in basename and sys.platform == "darwin":
+                with tempfile.NamedTemporaryFile() as tempf:
+                    download(url, tempf.name)
+                    app_path = f'{self.kinstall}/KNIME_{kver}.app'
+                    if os.path.exists(app_path):
+                        shutil.rmtree(app_path)
+                    with tempfile.TemporaryDirectory() as tempd:
+                        cmd = f'hdiutil mount -noverify {tempf.name} -mountpoint {tempd}/KNIME'
+                        subprocess_call(cmd, logger=logger)
+                        shutil.copytree(
+                            f'{tempd}/KNIME/KNIME {kver}.app',
+                            app_path
+                        )
+                        cmd = f'hdiutil unmount {tempd}/KNIME'
+                        subprocess_call(cmd, logger=logger)
+                break
+            elif "win32" in basename and sys.platform == "win32":
+                download_and_unzip(kurl, self.kinstall)
+                break
 
+        # Download Plugins
+        tempdir = tempfile.mkdtemp()
+        try:
+            path_plugins = []
+            for file in data["files"]:
+                basename = file["key"]
+                url = file["links"]["self"]
+                if "org.knime.update" in basename or "TrustedCommunity" in basename:
+                    path_plugin = os.path.join(tempdir, basename)
+                    download(url=url, file=path_plugin)
+                    path_plugins.append(path_plugin)
 
-    def __manage_pkgs(
-        self,
-        plugins_to_install: Optional[str] = DEFAULTS['KNIME_PLUGINS'],
-        plugins_to_remove: Optional[str] = [],
-        logger: Logger = getLogger(__name__)
-    ) -> int:
-        """Install KNIME packages needed to execute RetroPath2.0 workflow.
+            # Install Plugins
+            self.kexec = Knime.find_executable(path=self.kinstall)
+            p2_dir = Knime.find_p2_dir(path=self.kinstall)
+            knime_dir = [x for x in glob.glob(os.path.join(self.kinstall, "*")) if "knime" in x.lower()]
+            args = [f"{self.kexec}"]
+            args += ["-nosplash", "-consoleLog"]
+            args += ["-application", "org.eclipse.equinox.p2.director"]
+            args += ["-repository", ",".join([f"jar:file:{path_plugin}!/" for path_plugin in path_plugins])]
+            args += ["-bundlepool", p2_dir]
+            args += ["-destination", os.path.abspath(knime_dir[0])]
+            args += ["-i", "org.knime.features.chem.types.feature.group,org.knime.features.datageneration.feature.group,org.knime.features.python.feature.group,org.rdkit.knime.feature.feature.group,org.eclipse.equinox.preferences"]
 
-        Parameters
-        ----------
-        plugins_to_install: Optional[str]
-            KNIME plugins to install (separated by a comma).
-        plugins_to_remove: Optional[str]
-            KNIME plugins to remove (separated by a comma).
-        logger : Logger
-            The logger object.
-
-        Return
-        ------
-        int
-        """
-        StreamHandler.terminator = ""
-        logger.info( '   |- Checking KNIME packages...')
-        logger.debug(f'        + kpkg_install: {self.kpkg_install}')
-        logger.debug(f'        + kver: {self.kver}')
-        logger.debug(f'        + plugins to install: {plugins_to_install}')
-        logger.debug(f'        + plugins to remove: {plugins_to_remove}')
-
-        if plugins_to_install == plugins_to_remove == []:
-            StreamHandler.terminator = "\n"
-            logger.info(' OK')
-            return 0
-
-        # tmpdir = tempfile.mkdtemp()
-        # tmpdir = self.kinstall
-
-        args = [self.kexec]
-        args += ['-application', 'org.eclipse.equinox.p2.director']
-        args += ['-nosplash']
-        args += ['-consoleLog']
-        # # Download from Zenodo
-        # zenodo_query = self.zenodo_show_repo()
-        # repositories = []
-        # for zenodo_file in zenodo_query["files"]:
-        #     url = zenodo_file["links"]["self"]
-        #     if "update.analytics-platform" in url or "TrustedCommunityContributions" in url:
-        #         repo_path = os.path.join(tmpdir, os.path.basename(url))
-        #         if not os.path.exists(repo_path):
-        #             logger.info(f'        + Downloading {url} to {repo_path}...')
-        #             download(url, repo_path)
-        #         repositories.append(repo_path)
-        args += ["-repository"] + [','.join(DEFAULTS['KNIME_REPOS'])]
-        # args.append(",".join(["jar:file:%s!/" % (x,) for x in repositories]))
-        args += ['-bundlepool', self.kpkg_install]
-        args += ['-destination', self.kpkg_install]
-
-        _args = []
-        if plugins_to_remove:
-            _args = ['-uninstallIU'] + [','.join(plugins_to_remove)]
-            # CPE = subprocess_call(" ".join(args+_args), logger=logger)
-
-        if plugins_to_install:
-            _args = ["-installIU"] + [','.join(plugins_to_install)]
-
-        CPE = subprocess_call(" ".join(args+_args), logger=logger)
-
-        StreamHandler.terminator = "\n"
-        # shutil.rmtree(tmpdir, ignore_errors=True)
-
-        logger.info(' OK')
-        return CPE.returncode
-
-
-    def install(self, logger: Logger = getLogger(__name__)) -> int:
-        logger.debug(f'kexec_install: {self.kexec_install}')
-
-        r_code = 0
-
-        if not self.network:
-            logger.warning('Unable to install KNIME nor plugins because network is disabled (--no-network).')
-            return r_code
-
-        # If order to install, install exec and pkgs
-        if self.kexec_install:
-            self.__install_exec(logger=logger)
-            plugins_to_install = self.plugins_default
-            plugins_to_remove = []
-        else:
-            plugins_installed = self.list_plugins(logger=logger)
-            plugins_to_install = self.detect_plugins_to_install(plugins_installed, logger)
-            # Build list of plugins to remove
-            # build list of plugin names to install
-            plugins_to_install_names = [pkg.name for pkg in plugins_to_install]
-            # build list of plugin names already installed
-            plugins_installed_names = [pkg.name for pkg in plugins_installed]
-            # build list of plugin names to remove
-            plugins_to_remove = list(
-                set(plugins_installed_names).intersection(set(plugins_to_install_names))
-            )
-
-        # transform lists of KPlugins into list of str
-        plugins_to_install = [str(pkg) for pkg in plugins_to_install]
-
-        r_code = self.__manage_pkgs(
-            plugins_to_install,
-            plugins_to_remove,
-            logger=logger
-        )
-
-        return r_code
-
-
-    def detect_plugins_to_install(
-        self,
-        plugins_installed: List[KPlugin],
-        logger: Logger = getLogger(__name__)
-    ) -> List[str]:
-        """Detect KNIME plugins to install.
-
-        Parameters
-        ----------
-        plugins_installed: List[KPlugin]
-            List of installed plugins.
-        logger : Logger
-            The logger object.
-
-        Return
-        ------
-        List[str]
-        """
-
-        # Be sure that plugins
-        #   - specified by the user
-        # will be installed/updated
-        plugins_to_install = list(
-            map(KPlugin, self.kplugins)
-        )
-
-        # Add plugins listed by default iff:
-        #   - not already installed
-        #   - AND not specified by the user
-        plugins_installed_names = [pkg.name for pkg in plugins_installed if pkg.name]
-        plugins_to_install_names = [pkg.name for pkg in plugins_to_install if pkg.name]
-        for pkg in self.plugins_default:
-            if pkg.name not in plugins_installed_names \
-                and pkg.name not in plugins_to_install_names:
-                # add pkg to 'plugins_to_install'
-                plugins_to_install.append(pkg)
-
-        # Remove duplicates
-        plugins_to_install = list(set(plugins_to_install))
-
-        # For plugins appearing several times in 'plugins_to_install',
-        # keep only the one with the most specified version (e.g. w/ '/4.6.0.v202202251621')
-        _plugins_to_install = plugins_to_install.copy()
-        plugins_to_install = []
-        for _pkg in _plugins_to_install:
-            _pkg_name = _pkg.name
-            # if pkg basename not in 'plugins_to_install'
-            if _pkg_name not in [
-                pkg.name for pkg in plugins_to_install
-            ]:
-                # keep pkg in the list of plugins to install
-                plugins_to_install.append(_pkg)
-            else:
-                # check if pkg version is specified
-                if '/' in _pkg:
-                    # if pkg version is specified, keep it
-                    plugins_to_install.append(_pkg)
-
-        # If plugin version is specified,
-        # remove it if:
-        #  - it is already installed,
-        #  - AND installed version > specified version
-        for pkg_to_install in plugins_to_install:
-            # version is specified
-            if pkg_to_install.has_version():
-                # if pkg is already installed
-                for pkg_installed in plugins_installed:
-                    if pkg_to_install.name == pkg_installed.name:
-                        if pkg_to_install.version <= pkg_installed.version:
-                            # remove pkg from 'plugins_to_install'
-                            plugins_to_install.remove(pkg_to_install)
-                            break
-
-        return plugins_to_install
-
-
-    def list_plugins(self, logger: Logger = getLogger(__name__)) -> list:
-        """List KNIME plugins.
-
-        Parameters
-        ----------
-        logger : Logger
-            The logger object.
-
-        Return
-        ------
-        list
-        """
-        args = [self.kexec]
-        args += ['-application', 'org.eclipse.equinox.p2.director']
-        args += ['-nosplash']
-        args += ['-consoleLog']
-        args += ['-lir']
-        args += ['-d', self.kpkg_install]
-        CPE = subprocess_call(
-            " ".join(args),
-            stdout=sp_PIPE,
-            logger=logger
-        )
-
-        return [
-            KPlugin(elt)
-            for elt in CPE.stdout.decode('utf-8').split("\n")
-            if (elt.startswith('org.') or elt.startswith('com.'))
-        ]
-
+            CPE = subprocess.run(args)
+            logger.debug(CPE)
+        except Exception as error:
+            logger.error(error)
+        finally:
+            # Clean up
+            shutil.rmtree(tempdir)
+        return True
 
     def call(
         self,
@@ -568,3 +274,26 @@ class Knime(object):
             return RETCODES['OSError']
 
 
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--kinstall", required=True, help="Path to install Knime"
+    )
+    parser.add_argument(
+        "--kver", default="4.6.4", choices=["4.6.4", "4.7.0"], help="Knime version"
+    )
+    parser.add_argument(
+        "--overwrite", action="store_true", help="Install even if the executable is not present"
+    )
+    args = parser.parse_args()
+
+    path_knime = args.kinstall
+    kver = args.kver
+    to_overwrite = True if args.overwrite else False
+
+    os.makedirs(path_knime, exist_ok=True)
+    knime = Knime(kinstall=path_knime)
+
+    if to_overwrite or not knime.kexec:
+        knime.install(kver=kver)
+    


### PR DESCRIPTION
Simplify the use of Knime.
Remove arguments:
* `--kexec`
* `--kver`
* `--kplugins`
* `--no-network`
Use only:
* `--kinstall`
Will search a Knime executable in the `kinstall` directory. 
If no executable found, it will download Knime from Zenodo and install it.
If a knime executable is found, it will be used.

Knime can be installed through the command-line, before the use of Retropath2, with:
`python -m retropath2_wrapper.kinme --kinstall <path> -kver {4.6.4,4.7.0}`

